### PR TITLE
Fix num_iterations to be updated from the last iteration's current_iteration

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
@@ -555,6 +555,7 @@ private:
     std::vector<concatenated_memory_mapping> concatenated_output_mem_mappings;
 
     static std::string to_string(const loop_node& node);
+    size_t current_iteratoin_backedge_mapping_idx = 0;
 
 public:
     typed_primitive_inst(network_impl& network, const loop_node& node);
@@ -562,6 +563,12 @@ public:
     void preprocess_input_memory();
     void preprocess_output_memory();
     void preprocess_backedge_memory();
+    const backedge_memory_mapping& get_current_iteration_backedge_mapping() const {
+        if (!node.is_current_iteration_used()) {
+            CLDNN_ERROR_MESSAGE(node.id(), "no backedge mapping for current_iteration");
+        }
+        return backedge_memory_mappings.at(current_iteratoin_backedge_mapping_idx);
+    }
 
 private:
     network_impl::ptr body_network;

--- a/inference-engine/thirdparty/clDNN/src/loop.cpp
+++ b/inference-engine/thirdparty/clDNN/src/loop.cpp
@@ -291,6 +291,7 @@ void loop_inst::preprocess_backedge_memory() {
             initial_mem = get_network().get_engine().allocate_memory(current_iteration_layout);
             auto& stream = get_network().get_stream();
             loop_node::write_scalar_value(initial_mem, stream, 0);
+            current_iteratoin_backedge_mapping_idx = backedge_memory_mappings.size();
         } else {
             if (input_map_ptrs.size() == 0) {
                 CLDNN_ERROR_MESSAGE(id(), "no input_mapping for backedged input");


### PR DESCRIPTION
- num_iteration, the actual number of iteration, is the number in current_iteration of the last iteration. If current_iteration is not used, num_iteration is written as current_iteration_idx. 
- `int64_t current_iteration` in `loop_gpu::execute_impl()` renamed as `current_iteration_idx` to indicate that the variable is used as just loop counter. current_iteration in body is not related to current_iteration_idx
